### PR TITLE
Use setHeading and setTitle to better match official guidelines

### DIFF
--- a/src/search-modal.ts
+++ b/src/search-modal.ts
@@ -20,10 +20,11 @@ export class GeocodingSearchModal extends Modal {
 
 	onOpen() {
 		const { contentEl } = this;
-		contentEl.createEl("h1", {
-			text: "Confirm search term",
-		});
-		new Setting(contentEl).setName("Name").addText((text) => {
+		this.setTitle("Confirm search term");
+
+		const inputContainer = contentEl.createEl("div", { cls: "geocoding-search-container" });
+
+		new Setting(inputContainer).setName("Name").addText((text) => {
 			const component = text
 				.setValue(this.searchTerm)
 				.onChange((value) => {
@@ -32,14 +33,14 @@ export class GeocodingSearchModal extends Modal {
 			// increase width for easier editing
 			component.inputEl.style.width = "100%";
 		});
-		new Setting(contentEl).addButton((btn) =>
-			btn
-				.setButtonText("Submit")
-				.setCta()
-				.onClick(async () => {
-					await this.onSubmit();
-				})
-		);
+
+		const buttonContainer = contentEl.createEl("div", { cls: "modal-button-container" });
+
+		const submitButton = buttonContainer.createEl("button", { text: "Submit", cls: "mod-cta" });
+		submitButton.addEventListener("click", async () => {
+			await this.onSubmit();
+		});
+
 		// submit on enter (not sure why this doesn't work by default?)
 		contentEl.addEventListener("keypress", async (e) => {
 			if (e.key === "Enter") {

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -15,7 +15,6 @@ export class GeocodingPluginSettingTab extends PluginSettingTab {
 		const { containerEl } = this;
 		containerEl.empty();
 
-		containerEl.createEl("h2", { text: "Properties" });
 		for (const [key, description] of Object.entries(
 			propertyDescriptions
 		) as [GeocodingPropertyKey, GeocodingPropertyDescription][]) {
@@ -44,7 +43,8 @@ export class GeocodingPluginSettingTab extends PluginSettingTab {
 						})
 				);
 		}
-		containerEl.createEl("h2", { text: "Behavior" });
+
+		new Setting(containerEl).setName('Behavior').setHeading();
 		new Setting(containerEl)
 			.setName("Override existing properties")
 			.setDesc(
@@ -81,7 +81,7 @@ export class GeocodingPluginSettingTab extends PluginSettingTab {
 					})
 			);
 
-		containerEl.createEl("h2", { text: "API" });
+		new Setting(containerEl).setName('API').setHeading();
 		new Setting(containerEl)
 			.setName("API provider")
 			.addDropdown((dropdown) =>

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -15,6 +15,7 @@ export class GeocodingPluginSettingTab extends PluginSettingTab {
 		const { containerEl } = this;
 		containerEl.empty();
 
+		new Setting(containerEl).setName('Properties').setHeading();
 		for (const [key, description] of Object.entries(
 			propertyDescriptions
 		) as [GeocodingPropertyKey, GeocodingPropertyDescription][]) {


### PR DESCRIPTION
Better follow [official plugin guidelines](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#UI+text)

- Use `setHeading` for Settings headings
- Use `setTitle` and `.modal-button-container` to better match other modals in Obsidian.