### PR TITLE
Allow configuring search properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ Insert address / location data from geocoding APIs as Obsidian properties.
 
 ## Usage
 
-The plugin operates on the active note. It queries the configured geocoding API using one of the following search terms, in order of priority:
+The plugin operates on the active note. It queries the configured geocoding API using the search property order defined in the plugin settings. By default, the search term is resolved using the following priority list:
 
 -   The current note's `address` property, if set
 -   The current note's `title` property, if set
 -   The current note's name
+
+You can override this order in the settings if you prefer a different set of properties.
 
 The plugin provides two commands:
 
@@ -31,6 +33,10 @@ Each property can be enabled or disabled, and you can also specify a custom key 
 -   `map_view_link`: A link in in an [obsidian-map-view](https://github.com/esm7/obsidian-map-view)-compatible `[](geo:lat,lng)` format
 
 ### Property settings
+
+#### Search property order
+
+Controls which properties should be checked (and in what order) when building the geocoding search term. Provide a comma-separated list of property names; include `name` anywhere in the list to fall back to the note's filename.
 
 #### Override existing properties
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -176,7 +176,13 @@ export default class GeocodingPlugin extends Plugin {
 	}
 
 	async loadSettings() {
-		this.settings = merge(defaultSettings, (await this.loadData()) || {});
+		this.settings = merge(defaultSettings, (await this.loadData()) || {}, {
+			// Replace arrays instead of concatenating them,
+			// but fall back to defaults if user array is empty
+			arrayMerge: (destinationArray, sourceArray) => {
+				return sourceArray.length > 0 ? sourceArray : destinationArray;
+			},
+		});
 	}
 
 	async saveSettings() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,10 +52,9 @@ export default class GeocodingPlugin extends Plugin {
 	getSearchTerm(file: TFile) {
 		const metadataCache = this.app.metadataCache.getFileCache(file);
 		const frontmatter = metadataCache?.frontmatter;
-		const order =
-			this.settings.searchPropertyOrder?.length
-				? this.settings.searchPropertyOrder
-				: defaultSettings.searchPropertyOrder;
+		const order = this.settings.searchPropertyOrder?.length
+			? this.settings.searchPropertyOrder
+			: defaultSettings.searchPropertyOrder;
 		for (const rawKey of order) {
 			const key = rawKey?.trim();
 			if (!key) {
@@ -75,8 +74,8 @@ export default class GeocodingPlugin extends Plugin {
 				typeof value === "string"
 					? value
 					: Array.isArray(value)
-					? value.join(", ")
-					: String(value);
+						? value.join(", ")
+						: String(value);
 			if (stringValue.trim()) {
 				return stringValue;
 			}
@@ -93,16 +92,16 @@ export default class GeocodingPlugin extends Plugin {
 					results.push(
 						...(await fetchFreeGeocodingAPIResults(
 							searchTerm,
-							apiKey
-						))
+							apiKey,
+						)),
 					);
 					break;
 				case "google-geocoding":
 					results.push(
 						...(await fetchGoogleGeocodingResults(
 							searchTerm,
-							apiKey
-						))
+							apiKey,
+						)),
 					);
 					break;
 				default:
@@ -129,7 +128,7 @@ export default class GeocodingPlugin extends Plugin {
 		this.app.fileManager.processFrontMatter(currentFile, (frontmatter) => {
 			for (const [key, property] of Object.entries(properties) as [
 				GeocodingPropertyKey,
-				GeocodingProperty
+				GeocodingProperty,
 			][]) {
 				const shouldInsert =
 					property.enabled &&
@@ -162,9 +161,8 @@ export default class GeocodingPlugin extends Plugin {
 						}
 						break;
 					case "map_view_link": {
-						frontmatter[
-							property.frontmatterKey
-						] = `[](geo:${result.lat},${result.lng})`;
+						frontmatter[property.frontmatterKey] =
+							`[](geo:${result.lat},${result.lng})`;
 						break;
 					}
 					default:

--- a/src/results-modal.ts
+++ b/src/results-modal.ts
@@ -15,7 +15,7 @@ export class GeocodingResultsModal extends SuggestModal<GeocodingResult> {
 
 	getSuggestions(query: string) {
 		return this.results.filter((result) =>
-			result.address.toLowerCase().includes(query.toLowerCase())
+			result.address.toLowerCase().includes(query.toLowerCase()),
 		);
 	}
 
@@ -25,7 +25,7 @@ export class GeocodingResultsModal extends SuggestModal<GeocodingResult> {
 
 	renderSuggestion(
 		{ address, lat, lng, info }: GeocodingResult,
-		el: HTMLElement
+		el: HTMLElement,
 	) {
 		el.createEl("div", {
 			text: `${address} (${lat}, ${lng})`,

--- a/src/search-modal.ts
+++ b/src/search-modal.ts
@@ -20,7 +20,7 @@ export class GeocodingSearchModal extends Modal {
 
 	onOpen() {
 		const { contentEl } = this;
-		this.setTitle("Confirm search term");
+		this.titleEl.setText("Confirm search term");
 
 		const inputContainer = contentEl.createEl("div", { cls: "geocoding-search-container" });
 

--- a/src/search-modal.ts
+++ b/src/search-modal.ts
@@ -22,7 +22,9 @@ export class GeocodingSearchModal extends Modal {
 		const { contentEl } = this;
 		this.titleEl.setText("Confirm search term");
 
-		const inputContainer = contentEl.createEl("div", { cls: "geocoding-search-container" });
+		const inputContainer = contentEl.createEl("div", {
+			cls: "geocoding-search-container",
+		});
 
 		new Setting(inputContainer).setName("Name").addText((text) => {
 			const component = text
@@ -34,9 +36,14 @@ export class GeocodingSearchModal extends Modal {
 			component.inputEl.style.width = "100%";
 		});
 
-		const buttonContainer = contentEl.createEl("div", { cls: "modal-button-container" });
+		const buttonContainer = contentEl.createEl("div", {
+			cls: "modal-button-container",
+		});
 
-		const submitButton = buttonContainer.createEl("button", { text: "Submit", cls: "mod-cta" });
+		const submitButton = buttonContainer.createEl("button", {
+			text: "Submit",
+			cls: "mod-cta",
+		});
 		submitButton.addEventListener("click", async () => {
 			await this.onSubmit();
 		});

--- a/src/search-property-setting.ts
+++ b/src/search-property-setting.ts
@@ -1,0 +1,75 @@
+import { Setting } from "obsidian";
+import GeocodingPlugin from "./main";
+import { GeocodingPluginSettingTab } from "./settings-tab";
+import { moveElementUp, moveElementDown } from "./utils/array";
+
+const CLASS_NAMES = {
+	propertyInput: "geocoding-search-property-input",
+	propertyMoveButton: "geocoding-search-property-move-button",
+	propertyDeleteButton: "geocoding-search-property-delete-button",
+	propertyInfoEl: "geocoding-search-property-info-el",
+};
+
+export default class SearchPropertySetting extends Setting {
+	constructor(
+		plugin: GeocodingPlugin,
+		settingTab: GeocodingPluginSettingTab,
+		containerEl: HTMLElement,
+		value: string,
+		index: number
+	) {
+		super(containerEl);
+		this.addText((cb) =>
+			cb
+				.setValue(value)
+				.setPlaceholder("Property name")
+				.onChange(async (newValue) => {
+					plugin.settings.searchPropertyOrder[index] = newValue;
+					await plugin.saveSettings();
+				})
+				.inputEl.addClass(CLASS_NAMES.propertyInput)
+		)
+			.addExtraButton((cb) =>
+				cb
+					.setIcon("move-up")
+					.setDisabled(index === 0)
+					.onClick(async () => {
+						moveElementUp(
+							plugin.settings.searchPropertyOrder,
+							index
+						);
+						await plugin.saveSettings();
+						settingTab.display();
+					})
+					.extraSettingsEl.addClass(CLASS_NAMES.propertyMoveButton)
+			)
+			.addExtraButton((cb) =>
+				cb
+					.setIcon("move-down")
+					.setDisabled(
+						index === plugin.settings.searchPropertyOrder.length - 1
+					)
+					.onClick(async () => {
+						moveElementDown(
+							plugin.settings.searchPropertyOrder,
+							index
+						);
+						await plugin.saveSettings();
+						settingTab.display();
+					})
+					.extraSettingsEl.addClass(CLASS_NAMES.propertyMoveButton)
+			)
+			.addExtraButton((cb) =>
+				cb
+					.setIcon("trash-2")
+					.onClick(async () => {
+						plugin.settings.searchPropertyOrder.splice(index, 1);
+						await plugin.saveSettings();
+						settingTab.display();
+					})
+					.extraSettingsEl.addClass(CLASS_NAMES.propertyDeleteButton)
+			);
+		this.infoEl.addClass(CLASS_NAMES.propertyInfoEl);
+		return this;
+	}
+}

--- a/src/search-property-setting.ts
+++ b/src/search-property-setting.ts
@@ -16,7 +16,7 @@ export default class SearchPropertySetting extends Setting {
 		settingTab: GeocodingPluginSettingTab,
 		containerEl: HTMLElement,
 		value: string,
-		index: number
+		index: number,
 	) {
 		super(containerEl);
 		this.addText((cb) =>
@@ -27,7 +27,7 @@ export default class SearchPropertySetting extends Setting {
 					plugin.settings.searchPropertyOrder[index] = newValue;
 					await plugin.saveSettings();
 				})
-				.inputEl.addClass(CLASS_NAMES.propertyInput)
+				.inputEl.addClass(CLASS_NAMES.propertyInput),
 		)
 			.addExtraButton((cb) =>
 				cb
@@ -36,28 +36,29 @@ export default class SearchPropertySetting extends Setting {
 					.onClick(async () => {
 						moveElementUp(
 							plugin.settings.searchPropertyOrder,
-							index
+							index,
 						);
 						await plugin.saveSettings();
 						settingTab.display();
 					})
-					.extraSettingsEl.addClass(CLASS_NAMES.propertyMoveButton)
+					.extraSettingsEl.addClass(CLASS_NAMES.propertyMoveButton),
 			)
 			.addExtraButton((cb) =>
 				cb
 					.setIcon("move-down")
 					.setDisabled(
-						index === plugin.settings.searchPropertyOrder.length - 1
+						index ===
+							plugin.settings.searchPropertyOrder.length - 1,
 					)
 					.onClick(async () => {
 						moveElementDown(
 							plugin.settings.searchPropertyOrder,
-							index
+							index,
 						);
 						await plugin.saveSettings();
 						settingTab.display();
 					})
-					.extraSettingsEl.addClass(CLASS_NAMES.propertyMoveButton)
+					.extraSettingsEl.addClass(CLASS_NAMES.propertyMoveButton),
 			)
 			.addExtraButton((cb) =>
 				cb
@@ -67,7 +68,7 @@ export default class SearchPropertySetting extends Setting {
 						await plugin.saveSettings();
 						settingTab.display();
 					})
-					.extraSettingsEl.addClass(CLASS_NAMES.propertyDeleteButton)
+					.extraSettingsEl.addClass(CLASS_NAMES.propertyDeleteButton),
 			);
 		this.infoEl.addClass(CLASS_NAMES.propertyInfoEl);
 		return this;

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -1,6 +1,6 @@
 import { App, PluginSettingTab, Setting } from "obsidian";
 import GeocodingPlugin from "./main";
-import { propertyDescriptions } from "./settings";
+import { defaultSettings, propertyDescriptions } from "./settings";
 import { GeocodingPropertyDescription, GeocodingPropertyKey } from "./types";
 
 export class GeocodingPluginSettingTab extends PluginSettingTab {
@@ -46,6 +46,31 @@ export class GeocodingPluginSettingTab extends PluginSettingTab {
 		}
 
 		new Setting(containerEl).setName('Behavior').setHeading();
+		new Setting(containerEl)
+			.setName("Search property order")
+			.setDesc(
+				"Comma-separated list of properties to use when querying the geocoding API. Use \"name\" to fall back to the note name."
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder(
+						defaultSettings.searchPropertyOrder.join(",")
+					)
+					.setValue(
+						this.plugin.settings.searchPropertyOrder.join(",")
+					)
+					.onChange(async (value) => {
+						const nextOrder = value
+							.split(",")
+							.map((item) => item.trim())
+							.filter(Boolean);
+						this.plugin.settings.searchPropertyOrder =
+							nextOrder.length
+								? nextOrder
+								: [...defaultSettings.searchPropertyOrder];
+						await this.plugin.saveSettings();
+					})
+			);
 		new Setting(containerEl)
 			.setName("Override existing properties")
 			.setDesc(

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -1,7 +1,8 @@
 import { App, PluginSettingTab, Setting } from "obsidian";
 import GeocodingPlugin from "./main";
-import { defaultSettings, propertyDescriptions } from "./settings";
+import { propertyDescriptions } from "./settings";
 import { GeocodingPropertyDescription, GeocodingPropertyKey } from "./types";
+import SearchPropertySetting from "./search-property-setting";
 
 export class GeocodingPluginSettingTab extends PluginSettingTab {
 	plugin: GeocodingPlugin;
@@ -15,7 +16,7 @@ export class GeocodingPluginSettingTab extends PluginSettingTab {
 		const { containerEl } = this;
 		containerEl.empty();
 
-		new Setting(containerEl).setName('Properties').setHeading();
+		new Setting(containerEl).setName("Properties").setHeading();
 		for (const [key, description] of Object.entries(
 			propertyDescriptions
 		) as [GeocodingPropertyKey, GeocodingPropertyDescription][]) {
@@ -45,32 +46,30 @@ export class GeocodingPluginSettingTab extends PluginSettingTab {
 				);
 		}
 
-		new Setting(containerEl).setName('Behavior').setHeading();
+		new Setting(containerEl).setName("Behavior").setHeading();
 		new Setting(containerEl)
 			.setName("Search property order")
 			.setDesc(
-				"Comma-separated list of properties to use when querying the geocoding API. Use \"name\" to fall back to the note name."
+				'Properties to use when querying the geocoding API. Use "name" to fall back to the note name.'
 			)
-			.addText((text) =>
-				text
-					.setPlaceholder(
-						defaultSettings.searchPropertyOrder.join(",")
-					)
-					.setValue(
-						this.plugin.settings.searchPropertyOrder.join(",")
-					)
-					.onChange(async (value) => {
-						const nextOrder = value
-							.split(",")
-							.map((item) => item.trim())
-							.filter(Boolean);
-						this.plugin.settings.searchPropertyOrder =
-							nextOrder.length
-								? nextOrder
-								: [...defaultSettings.searchPropertyOrder];
-						await this.plugin.saveSettings();
-					})
-			);
+			.setHeading();
+		this.plugin.settings.searchPropertyOrder.forEach(
+			(property, index) =>
+				new SearchPropertySetting(
+					this.plugin,
+					this,
+					containerEl,
+					property,
+					index
+				)
+		);
+		new Setting(containerEl).addExtraButton((cb) =>
+			cb.setIcon("circle-plus").onClick(async () => {
+				this.plugin.settings.searchPropertyOrder.push("");
+				await this.plugin.saveSettings();
+				this.display();
+			})
+		);
 		new Setting(containerEl)
 			.setName("Override existing properties")
 			.setDesc(
@@ -107,7 +106,7 @@ export class GeocodingPluginSettingTab extends PluginSettingTab {
 					})
 			);
 
-		new Setting(containerEl).setName('API').setHeading();
+		new Setting(containerEl).setName("API").setHeading();
 		new Setting(containerEl)
 			.setName("API provider")
 			.addDropdown((dropdown) =>

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -18,7 +18,7 @@ export class GeocodingPluginSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl).setName("Properties").setHeading();
 		for (const [key, description] of Object.entries(
-			propertyDescriptions
+			propertyDescriptions,
 		) as [GeocodingPropertyKey, GeocodingPropertyDescription][]) {
 			const property = this.plugin.settings.properties[key];
 			new Setting(containerEl)
@@ -34,7 +34,7 @@ export class GeocodingPluginSettingTab extends PluginSettingTab {
 							}
 							property.frontmatterKey = value;
 							await this.plugin.saveSettings();
-						})
+						}),
 				)
 				.addToggle((toggle) =>
 					toggle
@@ -42,38 +42,15 @@ export class GeocodingPluginSettingTab extends PluginSettingTab {
 						.onChange(async (value) => {
 							property.enabled = value;
 							await this.plugin.saveSettings();
-						})
+						}),
 				);
 		}
 
 		new Setting(containerEl).setName("Behavior").setHeading();
 		new Setting(containerEl)
-			.setName("Search property order")
-			.setDesc(
-				'Properties to use when querying the geocoding API. Use "name" to fall back to the note name.'
-			)
-			.setHeading();
-		this.plugin.settings.searchPropertyOrder.forEach(
-			(property, index) =>
-				new SearchPropertySetting(
-					this.plugin,
-					this,
-					containerEl,
-					property,
-					index
-				)
-		);
-		new Setting(containerEl).addExtraButton((cb) =>
-			cb.setIcon("circle-plus").onClick(async () => {
-				this.plugin.settings.searchPropertyOrder.push("");
-				await this.plugin.saveSettings();
-				this.display();
-			})
-		);
-		new Setting(containerEl)
 			.setName("Override existing properties")
 			.setDesc(
-				"Whether to override existing properties with the same name"
+				"Whether to override existing properties with the same name",
 			)
 			.addToggle((toggle) =>
 				toggle
@@ -81,7 +58,7 @@ export class GeocodingPluginSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.overrideExistingProperties = value;
 						await this.plugin.saveSettings();
-					})
+					}),
 			);
 		new Setting(containerEl)
 			.setName("Map link provider")
@@ -103,8 +80,46 @@ export class GeocodingPluginSettingTab extends PluginSettingTab {
 								break;
 						}
 						await this.plugin.saveSettings();
-					})
+					}),
 			);
+		new Setting(containerEl)
+			.setName("Search property order")
+			.setDesc(
+				'Properties to use when querying the geocoding API. Use "name" to fall back to the note name.',
+			)
+			.setHeading();
+		this.plugin.settings.searchPropertyOrder.forEach(
+			(property, index) =>
+				new SearchPropertySetting(
+					this.plugin,
+					this,
+					containerEl,
+					property,
+					index,
+				),
+		);
+		let newSearchProperty = "";
+		const newSearchInput = new Setting(containerEl)
+			.addText((cb) => {
+				cb.onChange((value) => (newSearchProperty = value));
+				cb.inputEl.classList.add(
+					"geocoding-search-property-new-property-input",
+				);
+			})
+			.addExtraButton((cb) =>
+				cb.setIcon("circle-plus").onClick(async () => {
+					if (!newSearchProperty) return;
+
+					this.plugin.settings.searchPropertyOrder.push(
+						newSearchProperty,
+					);
+					await this.plugin.saveSettings();
+					this.display();
+				}),
+			);
+		newSearchInput.infoEl.classList.add(
+			"geocoding-search-property-info-el",
+		);
 
 		new Setting(containerEl).setName("API").setHeading();
 		new Setting(containerEl)
@@ -124,12 +139,12 @@ export class GeocodingPluginSettingTab extends PluginSettingTab {
 								break;
 						}
 						await this.plugin.saveSettings();
-					})
+					}),
 			);
 		new Setting(containerEl)
 			.setName("API key")
 			.setDisabled(
-				this.plugin.settings.apiProvider !== "google-geocoding"
+				this.plugin.settings.apiProvider !== "google-geocoding",
 			)
 			.addText((text) =>
 				text
@@ -137,7 +152,7 @@ export class GeocodingPluginSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.apiKey = value;
 						await this.plugin.saveSettings();
-					})
+					}),
 			);
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -59,6 +59,7 @@ export const defaultSettings: GeocodingPluginSettings = {
 		},
 	},
 	overrideExistingProperties: false,
+	searchPropertyOrder: ["address", "title", "name"],
 	mapLinkProvider: "google",
 	apiProvider: "free-geocoding-api",
 	apiKey: "",

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface GeocodingProperty {
 export interface GeocodingPluginSettings {
 	properties: Record<GeocodingPropertyKey, GeocodingProperty>;
 	overrideExistingProperties: boolean;
+	searchPropertyOrder: string[];
 	mapLinkProvider: MapLinkProvider;
 	apiProvider: GeocodingProvider;
 	apiKey: string;

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,9 @@
+export const moveElementUp = (array: unknown[], index: number) => {
+	if (array[index - 1] === undefined) return;
+	[array[index], array[index - 1]] = [array[index - 1], array[index]];
+};
+
+export const moveElementDown = (array: unknown[], index: number) => {
+	if (array[index + 1] === undefined) return;
+	[array[index], array[index + 1]] = [array[index + 1], array[index]];
+};

--- a/src/utils/fetch-free-geocoding-api-results.ts
+++ b/src/utils/fetch-free-geocoding-api-results.ts
@@ -4,7 +4,7 @@ import { FreeGeocodingAPIResult, GeocodingResult } from "../types";
 // https://geocode.maps.co
 export const fetchFreeGeocodingAPIResults = async (
 	searchTerm: string,
-	apiKey: string
+	apiKey: string,
 ): Promise<GeocodingResult[]> => {
 	const params = new URLSearchParams({
 		q: searchTerm,
@@ -25,7 +25,7 @@ export const fetchFreeGeocodingAPIResults = async (
 		case 503:
 			if (retryAfter) {
 				throw new Error(
-					`Too many requests. Please try again in ${retryAfter} seconds.`
+					`Too many requests. Please try again in ${retryAfter} seconds.`,
 				);
 			}
 			throw new Error("Too many requests. Please try again later.");

--- a/src/utils/fetch-google-geocoding-results.ts
+++ b/src/utils/fetch-google-geocoding-results.ts
@@ -4,7 +4,7 @@ import { GeocodingResult, GoogleGeocodingAPIResponse } from "../types";
 // https://developers.google.com/maps/documentation/geocoding/overview
 export const fetchGoogleGeocodingResults = async (
 	searchTerm: string,
-	apiKey: string
+	apiKey: string,
 ): Promise<GeocodingResult[]> => {
 	const params = new URLSearchParams({
 		address: searchTerm,

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,16 @@
+.geocoding-search-property-input {
+	width: 100%;
+}
+
+.geocoding-search-property-move-button.is-disabled {
+	pointer-events: none;
+	opacity: 0.2;
+}
+
+.geocoding-search-property-delete-button {
+	color: var(--color-red);
+}
+
+.geocoding-search-property-info-el {
+	display: none;
+}

--- a/styles.css
+++ b/styles.css
@@ -14,3 +14,7 @@
 .geocoding-search-property-info-el {
 	display: none;
 }
+
+.geocoding-search-property-new-property-input {
+	flex: 1;
+}


### PR DESCRIPTION
I've added the ability to customize the search fields - useful when you want to geocode existing notes that don't have an "address" property

<img width="814" height="145" alt="image" src="https://github.com/user-attachments/assets/c37dd23c-65c5-4e61-9268-39af513ae7b8" />
